### PR TITLE
changes need to run the apps for iOS and Android under .NET 8

### DIFF
--- a/MauiDependencyInjectionSample/MainPage.xaml.cs
+++ b/MauiDependencyInjectionSample/MainPage.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Maui.Controls;
-using Microsoft.Maui.Essentials;
 using System;
 
 namespace MauiDependencyInjectionSample
@@ -19,8 +18,6 @@ namespace MauiDependencyInjectionSample
         {
             count++;
             CounterLabel.Text = $"Current count: {count}";
-
-            SemanticScreenReader.Announce(CounterLabel.Text);
         }
     }
 }

--- a/MauiDependencyInjectionSample/MauiDependencyInjectionSample.csproj
+++ b/MauiDependencyInjectionSample/MauiDependencyInjectionSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-ios;net6.0-android;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0-ios;net8.0-android;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiDependencyInjectionSample</RootNamespace>

--- a/MauiDependencyInjectionSample/Platforms/Android/MainApplication.cs
+++ b/MauiDependencyInjectionSample/Platforms/Android/MainApplication.cs
@@ -1,6 +1,7 @@
 ﻿using Android.App;
 using Android.Runtime;
 using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
 using System;
 
 namespace MauiDependencyInjectionSample

--- a/MauiDependencyInjectionSample/Platforms/iOS/AppDelegate.cs
+++ b/MauiDependencyInjectionSample/Platforms/iOS/AppDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using Foundation;
 using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
 
 namespace MauiDependencyInjectionSample
 {

--- a/MauiDependencyInjectionSample/Platforms/iOS/Info.plist
+++ b/MauiDependencyInjectionSample/Platforms/iOS/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>MinimumOSVersion</key>
-	<string>10.3.4</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
Hi, Gerald.  This PR simply makes the iOS and Android apps run under .NET 8.  I wanted to check whether .NET 8 would break the injection of your MainPage into the App constructor, but it didn't.  I'm getting the same behavior as this SO post that you replied to: https://stackoverflow.com/questions/72429297/injecting-services-into-view-models-in-net-maui-app.  I will now reply to your comment there.  I'm getting the same problem as poster did, and I'm hoping you can help me.  My .NET 8 project where it happens is in my branch here: https://github.com/tele-bird/mauipoc/tree/inject-appshell-into-app-constructor